### PR TITLE
Stop sending random crap in tcp-echo-server

### DIFF
--- a/examples/05-tcp-echo-server/main.c
+++ b/examples/05-tcp-echo-server/main.c
@@ -63,11 +63,12 @@ void read_cb(uv_stream_t *client, ssize_t nread, const uv_buf_t *buf) {
     (*readp) = nread;
     // communicate number of bytes we are writing to write_cb
     req->data = readp;
+    uv_buf_t wbuf = uv_buf_init(buf->base, nread);
 
     // uvbook assigns req->data to buf->base here to free it in write_cb
     // (https://github.com/nikhilm/uvbook/blob/79d441bf695f2342f590962f74f4be788890f428/code/tcp-echo-server/main.c#L30),
     // but freeing right after calling uv_write works just fine
-    uv_write(req, client, buf, 1/*nbufs*/, write_cb);
+    uv_write(req, client, &wbuf, 1/*nbufs*/, write_cb);
     //fprintf(stderr, "writing %ld bytes\n", req->bufs[0].len);
   }
   if (buf->base) free(buf->base);


### PR DESCRIPTION
tcp-echo-server currently sends an unaltered buf out, which is bad since buf.len can be much larger than nread. This can lead to sending thousands of null bytes, to just sending random crap out on the wire.

Trivial python script that illustrates the problem: https://gist.github.com/nickelpro/fa2ca0fd7ffa39b5d8da

Only safe for single client server, two clients and bad things happen. But we're already freeing base in the read callback so obviously we live on the wild side.
